### PR TITLE
Add prompt sanitization and encoding toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
-# Coding
-Coding Ideas
+# Prompt Guard
+
+A lightweight Python toolkit that screens prompts for sensitive information,
+replaces those segments with deterministic placeholders, and encrypts the
+sanitized payload before it is sent to a prompt engine.  Responses can be
+decrypted and restored to their original form once the model reply is received.
+
+## Features
+
+- Configurable regular-expression based detector for client names, KPI metrics,
+  account numbers, and emails.
+- Deterministic placeholder mapping that keeps track of sensitive values.
+- Simple symmetric cipher (XOR with SHA-256 derived keystream) to obfuscate
+  sanitized payloads without third-party dependencies.
+- High-level pipeline class that coordinates detection, masking, encryption, and
+  response restoration.
+
+## Quick start
+
+```bash
+python -m prompt_guard.example
+```
+
+The example script prints the encoded payload, the detected matches, and the
+decoded response, illustrating how the placeholders are restored.
+
+## Usage
+
+```python
+from prompt_guard import PromptGuard
+
+guard = PromptGuard(secret="your-shared-secret")
+user_prompt = "Share ARR forecast for Acme Corp and email finance@acme.com"
+
+encoded_prompt = guard.prepare_prompt(user_prompt)
+# -> encoded_prompt.encoded_payload contains the encrypted text ready for the model
+# -> encoded_prompt.matches keeps the placeholder metadata
+
+# Send encoded_prompt.encoded_payload to your prompt engine...
+
+# Once the model replies, decrypt and restore:
+model_response = guard.recover_response(encoded_payload_from_model, encoded_prompt.matches)
+```
+
+> **Security note:** the bundled cipher is intended as a transport obfuscation
+> layer to keep the example self-contained.  Replace it with a production-grade
+> encryption mechanism and managed key infrastructure when handling real-world
+> confidential information.

--- a/prompt_guard/__init__.py
+++ b/prompt_guard/__init__.py
@@ -1,0 +1,14 @@
+"""Prompt Guard package."""
+
+from .detector import SensitiveInfoDetector, SensitiveMatch, SensitivePattern
+from .cipher import PromptCipher
+from .pipeline import PromptGuard, EncodedPrompt
+
+__all__ = [
+    "SensitiveInfoDetector",
+    "SensitiveMatch",
+    "SensitivePattern",
+    "PromptCipher",
+    "PromptGuard",
+    "EncodedPrompt",
+]

--- a/prompt_guard/cipher.py
+++ b/prompt_guard/cipher.py
@@ -1,0 +1,40 @@
+"""Lightweight symmetric cipher for prompt payloads.
+
+The implementation is intentionally simple and avoids external dependencies so
+that it can run in restricted environments.  It should be viewed as a transport
+obfuscation layer rather than a drop-in replacement for production grade
+cryptography.  For sensitive deployments consider using a well vetted library
+such as ``cryptography`` and managed keys.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+from itertools import cycle
+from typing import Final
+
+
+class PromptCipher:
+    """Symmetric cipher that performs XOR with a SHA-256 derived key."""
+
+    _BLOCK_SIZE: Final[int] = 32
+
+    def __init__(self, secret: str):
+        if not secret:
+            raise ValueError("Secret must not be empty")
+        self._key = hashlib.sha256(secret.encode("utf-8")).digest()
+
+    def _expand_key(self, length: int) -> bytes:
+        return bytes(k for k, _ in zip(cycle(self._key), range(length)))
+
+    def encrypt(self, message: str) -> str:
+        data = message.encode("utf-8")
+        keystream = self._expand_key(len(data))
+        cipher_bytes = bytes(b ^ k for b, k in zip(data, keystream))
+        return base64.urlsafe_b64encode(cipher_bytes).decode("ascii")
+
+    def decrypt(self, token: str) -> str:
+        data = base64.urlsafe_b64decode(token.encode("ascii"))
+        keystream = self._expand_key(len(data))
+        plain_bytes = bytes(b ^ k for b, k in zip(data, keystream))
+        return plain_bytes.decode("utf-8")

--- a/prompt_guard/detector.py
+++ b/prompt_guard/detector.py
@@ -1,0 +1,110 @@
+"""Utilities for identifying and masking sensitive information in prompts."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable, List, Pattern, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class SensitivePattern:
+    """Configuration for a sensitive information pattern."""
+
+    label: str
+    pattern: Pattern[str]
+
+
+@dataclass(frozen=True)
+class SensitiveMatch:
+    """Represents a single sensitive segment detected in a prompt."""
+
+    label: str
+    value: str
+    placeholder: str
+    start: int
+    end: int
+
+
+class SensitiveInfoDetector:
+    """Detects and masks sensitive entities inside prompts."""
+
+    def __init__(self, patterns: Iterable[SensitivePattern]):
+        patterns = tuple(patterns)
+        if not patterns:
+            raise ValueError("At least one SensitivePattern is required")
+        self._patterns: Tuple[SensitivePattern, ...] = patterns
+
+    @staticmethod
+    def default_patterns() -> Tuple[SensitivePattern, ...]:
+        """Return a curated set of default detection rules."""
+
+        client_names = r"\b(?:Acme Corp|Globex|Initech|Umbrella|Hooli|Vehement Capital Partners)\b"
+        kpi_values = (
+            r"\b(?:revenue|ebitda|profit|conversion rate|churn rate|"
+            r"net promoter score|ARR|customer acquisition cost)\b[^\n]*?\d[\w$%,.-]*"
+        )
+        card_like = r"\b(?:\d[ -]?){13,16}\b"
+        email_like = r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
+        return (
+            SensitivePattern("client_name", re.compile(client_names, re.IGNORECASE)),
+            SensitivePattern("kpi", re.compile(kpi_values, re.IGNORECASE)),
+            SensitivePattern("possible_account_number", re.compile(card_like)),
+            SensitivePattern("email", re.compile(email_like)),
+        )
+
+    def scan(self, text: str) -> List[SensitiveMatch]:
+        """Scan ``text`` for sensitive information and return the matches."""
+
+        spans: List[Tuple[int, int, SensitivePattern, str]] = []
+        for pattern in self._patterns:
+            for match in pattern.pattern.finditer(text):
+                spans.append((match.start(), match.end(), pattern, match.group(0)))
+
+        spans.sort(key=lambda item: (item[0], -(item[1] - item[0])))
+
+        matches: List[SensitiveMatch] = []
+        last_end = -1
+        counter = 1
+        for start, end, pattern, value in spans:
+            if start < last_end:
+                # Skip overlapping matches, keep the earliest occurrence.
+                continue
+            placeholder = f"{{{{SENSITIVE_{counter}}}}}"
+            matches.append(
+                SensitiveMatch(
+                    label=pattern.label,
+                    value=value,
+                    placeholder=placeholder,
+                    start=start,
+                    end=end,
+                )
+            )
+            counter += 1
+            last_end = end
+        return matches
+
+    def mask(self, text: str) -> Tuple[str, List[SensitiveMatch]]:
+        """Mask sensitive segments in ``text`` and return the sanitized prompt."""
+
+        matches = self.scan(text)
+        if not matches:
+            return text, []
+
+        result_parts = []
+        last_idx = 0
+        for match in matches:
+            result_parts.append(text[last_idx:match.start])
+            result_parts.append(match.placeholder)
+            last_idx = match.end
+        result_parts.append(text[last_idx:])
+
+        sanitized = "".join(result_parts)
+        return sanitized, matches
+
+    def restore(self, text: str, matches: Sequence[SensitiveMatch]) -> str:
+        """Restore previously masked placeholders with their original values."""
+
+        restored = text
+        for match in matches:
+            restored = restored.replace(match.placeholder, match.value)
+        return restored

--- a/prompt_guard/example.py
+++ b/prompt_guard/example.py
@@ -1,0 +1,30 @@
+"""Example usage of the prompt guard pipeline."""
+from __future__ import annotations
+
+from .pipeline import PromptGuard
+
+
+def run_example() -> None:
+    guard = PromptGuard(secret="demo-secret")
+    prompt = (
+        "Draft a client update for Acme Corp. Include revenue: $5.2M, "
+        "net promoter score 62%, and email john.doe@acme.com for approval."
+    )
+
+    encoded = guard.prepare_prompt(prompt)
+    print("Encoded payload:", encoded.encoded_payload)
+    print("Detected matches:")
+    for match in encoded.matches:
+        print(f" - {match.label}: {match.value} -> {match.placeholder}")
+
+    # Simulate model response by echoing the sanitized prompt.
+    fake_model_response = guard.cipher.encrypt(
+        "The update for {{SENSITIVE_1}} with {{SENSITIVE_2}} was approved by {{SENSITIVE_4}}."
+    )
+
+    decoded = guard.recover_response(fake_model_response, encoded.matches)
+    print("Decoded response:", decoded)
+
+
+if __name__ == "__main__":
+    run_example()

--- a/prompt_guard/pipeline.py
+++ b/prompt_guard/pipeline.py
@@ -1,0 +1,43 @@
+"""High level utilities for sanitizing, encoding and decoding prompts."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from .cipher import PromptCipher
+from .detector import SensitiveInfoDetector, SensitiveMatch
+
+
+@dataclass
+class EncodedPrompt:
+    """Container returned by :class:`PromptGuard` after encoding a prompt."""
+
+    encoded_payload: str
+    matches: List[SensitiveMatch]
+
+
+class PromptGuard:
+    """Coordinate detection, masking and encoding of prompts."""
+
+    def __init__(
+        self,
+        *,
+        secret: str,
+        detector: Optional[SensitiveInfoDetector] = None,
+    ) -> None:
+        self.cipher = PromptCipher(secret)
+        self.detector = detector or SensitiveInfoDetector(SensitiveInfoDetector.default_patterns())
+
+    def prepare_prompt(self, prompt: str) -> EncodedPrompt:
+        """Detect sensitive data, mask it and return the encoded payload."""
+
+        sanitized, matches = self.detector.mask(prompt)
+        encoded = self.cipher.encrypt(sanitized)
+        return EncodedPrompt(encoded_payload=encoded, matches=list(matches))
+
+    def recover_response(self, encoded_response: str, matches: Iterable[SensitiveMatch]) -> str:
+        """Decode a response and restore previously masked values."""
+
+        decoded = self.cipher.decrypt(encoded_response)
+        restored = self.detector.restore(decoded, list(matches))
+        return restored


### PR DESCRIPTION
## Summary
- add a configurable sensitive information detector with masking support
- introduce a lightweight symmetric cipher and pipeline to encrypt sanitized prompts
- document usage and provide an executable example script

## Testing
- python -m prompt_guard.example

------
https://chatgpt.com/codex/tasks/task_e_68d6420ed7b4832e90217252b8e72fc9