### PR TITLE
Add simple web-based Minesweeper-style game

### DIFF
--- a/web/minesweeper/index.html
+++ b/web/minesweeper/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prompt Guard Minesweeper</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="app">
+    <header class="toolbar">
+      <h1 class="title">Minesweeper-ish</h1>
+      <div class="controls">
+        <button id="reset-btn" type="button">New Game</button>
+        <div class="status">
+          <span>Mines:</span>
+          <span id="mine-count">0</span>
+        </div>
+        <div class="status">
+          <span>Flags:</span>
+          <span id="flag-count">0</span>
+        </div>
+      </div>
+      <p id="message" class="message" role="status" aria-live="polite"></p>
+    </header>
+    <section id="board" class="board" role="grid" aria-label="Minesweeper board"></section>
+    <footer class="hint">
+      <p>Left click to reveal tiles. Right click (or long press) to toggle a flag.</p>
+    </footer>
+  </main>
+  <template id="tile-template">
+    <button class="tile" type="button" aria-live="polite"></button>
+  </template>
+  <script src="script.js" type="module"></script>
+</body>
+</html>

--- a/web/minesweeper/script.js
+++ b/web/minesweeper/script.js
@@ -1,0 +1,236 @@
+const BOARD_SIZE = 10;
+const MINE_COUNT = 15;
+
+const boardEl = document.getElementById('board');
+const resetBtn = document.getElementById('reset-btn');
+const mineCountEl = document.getElementById('mine-count');
+const flagCountEl = document.getElementById('flag-count');
+const messageEl = document.getElementById('message');
+const tileTemplate = document.getElementById('tile-template');
+
+let tiles = [];
+let flagsPlaced = 0;
+let safeTilesLeft = 0;
+let gameOver = false;
+let firstReveal = true;
+
+function buildBoard() {
+  tiles = Array.from({ length: BOARD_SIZE }, (_, row) =>
+    Array.from({ length: BOARD_SIZE }, (_, col) => ({
+      row,
+      col,
+      isMine: false,
+      isRevealed: false,
+      isFlagged: false,
+      adjacent: 0,
+      element: null,
+    }))
+  );
+
+  boardEl.innerHTML = '';
+  boardEl.style.setProperty('--board-size', BOARD_SIZE);
+
+  const fragment = document.createDocumentFragment();
+  for (const row of tiles) {
+    for (const tile of row) {
+      const tileEl = tileTemplate.content.firstElementChild.cloneNode(true);
+      tileEl.dataset.row = tile.row;
+      tileEl.dataset.col = tile.col;
+      tileEl.setAttribute('aria-label', 'Hidden tile');
+      tileEl.addEventListener('click', () => handleReveal(tile));
+      tileEl.addEventListener('contextmenu', (event) => {
+        event.preventDefault();
+        toggleFlag(tile);
+      });
+      tileEl.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          handleReveal(tile);
+        }
+        if (event.key.toLowerCase() === 'f') {
+          event.preventDefault();
+          toggleFlag(tile);
+        }
+      });
+      tile.element = tileEl;
+      fragment.appendChild(tileEl);
+    }
+  }
+
+  boardEl.appendChild(fragment);
+}
+
+function randomizeMines(excludedTile) {
+  const positions = [];
+  for (let row = 0; row < BOARD_SIZE; row++) {
+    for (let col = 0; col < BOARD_SIZE; col++) {
+      if (excludedTile && excludedTile.row === row && excludedTile.col === col) {
+        continue;
+      }
+      positions.push([row, col]);
+    }
+  }
+
+  shuffle(positions);
+
+  for (let i = 0; i < MINE_COUNT; i++) {
+    const [row, col] = positions[i];
+    tiles[row][col].isMine = true;
+  }
+
+  for (let row = 0; row < BOARD_SIZE; row++) {
+    for (let col = 0; col < BOARD_SIZE; col++) {
+      tiles[row][col].adjacent = countAdjacentMines(row, col);
+    }
+  }
+
+  safeTilesLeft = BOARD_SIZE * BOARD_SIZE - MINE_COUNT;
+  mineCountEl.textContent = MINE_COUNT.toString();
+  updateFlagDisplay();
+}
+
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
+
+function countAdjacentMines(row, col) {
+  if (tiles[row][col].isMine) {
+    return 0;
+  }
+  return getNeighbors(row, col).reduce(
+    (count, neighbor) => count + (neighbor.isMine ? 1 : 0),
+    0,
+  );
+}
+
+function getNeighbors(row, col) {
+  const neighbors = [];
+  for (let r = row - 1; r <= row + 1; r++) {
+    for (let c = col - 1; c <= col + 1; c++) {
+      if (r === row && c === col) continue;
+      if (r < 0 || c < 0 || r >= BOARD_SIZE || c >= BOARD_SIZE) continue;
+      neighbors.push(tiles[r][c]);
+    }
+  }
+  return neighbors;
+}
+
+function handleReveal(tile) {
+  if (gameOver || tile.isFlagged || tile.isRevealed) {
+    return;
+  }
+
+  if (firstReveal) {
+    randomizeMines(tile);
+    firstReveal = false;
+    messageEl.textContent = '';
+  }
+
+  if (tile.isMine) {
+    revealMine(tile);
+    endGame(false);
+    return;
+  }
+
+  floodReveal(tile);
+  if (safeTilesLeft === 0) {
+    endGame(true);
+  }
+}
+
+function floodReveal(startTile) {
+  const queue = [startTile];
+
+  while (queue.length > 0) {
+    const tile = queue.shift();
+    if (tile.isRevealed || tile.isFlagged) {
+      continue;
+    }
+
+    tile.isRevealed = true;
+    tile.element.classList.add('revealed');
+    tile.element.setAttribute('aria-label', tile.isMine ? 'Mine' : `Revealed tile with ${tile.adjacent} nearby`);
+    tile.element.textContent = tile.adjacent > 0 ? tile.adjacent : '';
+    safeTilesLeft -= 1;
+
+    if (tile.adjacent === 0) {
+      for (const neighbor of getNeighbors(tile.row, tile.col)) {
+        if (!neighbor.isRevealed && !neighbor.isMine) {
+          queue.push(neighbor);
+        }
+      }
+    }
+  }
+}
+
+function revealMine(tile) {
+  tile.isRevealed = true;
+  tile.element.classList.add('revealed', 'mine');
+  tile.element.textContent = '💣';
+  tile.element.setAttribute('aria-label', 'Mine');
+
+  for (const row of tiles) {
+    for (const other of row) {
+      if (other === tile) continue;
+      if (other.isMine) {
+        other.element.classList.add('revealed', 'mine');
+        other.element.textContent = '💣';
+        other.element.setAttribute('aria-label', 'Mine');
+      }
+      other.element.disabled = true;
+    }
+  }
+}
+
+function toggleFlag(tile) {
+  if (gameOver || tile.isRevealed) {
+    return;
+  }
+
+  tile.isFlagged = !tile.isFlagged;
+  tile.element.classList.toggle('flagged', tile.isFlagged);
+  tile.element.setAttribute('aria-label', tile.isFlagged ? 'Flagged tile' : 'Hidden tile');
+  flagsPlaced += tile.isFlagged ? 1 : -1;
+  updateFlagDisplay();
+}
+
+function updateFlagDisplay() {
+  flagCountEl.textContent = `${flagsPlaced}/${MINE_COUNT}`;
+}
+
+function endGame(won) {
+  gameOver = true;
+  messageEl.textContent = won ? '🎉 Cleared! All mines avoided.' : '💥 Boom! Try again?';
+  for (const row of tiles) {
+    for (const tile of row) {
+      tile.element.disabled = true;
+      if (won && tile.isMine) {
+        tile.element.classList.add('revealed', 'flagged');
+        tile.element.textContent = '🚩';
+        tile.element.setAttribute('aria-label', 'Mine located');
+      }
+      if (!won && !tile.isMine && tile.isFlagged) {
+        tile.element.classList.add('revealed');
+        tile.element.classList.remove('flagged');
+        tile.element.textContent = '✖';
+      }
+    }
+  }
+}
+
+function resetGame() {
+  gameOver = false;
+  firstReveal = true;
+  flagsPlaced = 0;
+  safeTilesLeft = BOARD_SIZE * BOARD_SIZE - MINE_COUNT;
+  messageEl.textContent = 'Tap a tile to begin.';
+  buildBoard();
+  updateFlagDisplay();
+}
+
+resetBtn.addEventListener('click', () => resetGame());
+
+resetGame();

--- a/web/minesweeper/styles.css
+++ b/web/minesweeper/styles.css
@@ -1,0 +1,169 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f6fb;
+  --bg-dark: #1f2330;
+  --accent: #4d74ff;
+  --accent-dark: #9ab0ff;
+  --tile-bg: rgba(255, 255, 255, 0.8);
+  --tile-border: rgba(0, 0, 0, 0.15);
+  --tile-revealed: rgba(77, 116, 255, 0.12);
+  font-family: 'Segoe UI', Tahoma, sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(160deg, var(--bg), #cbd5f5 60%);
+  color: #1b2135;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: linear-gradient(160deg, var(--bg-dark), #111521 60%);
+    color: #e9edff;
+  }
+}
+
+.app {
+  width: min(90vw, 480px);
+  display: grid;
+  gap: 1rem;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 20px 35px rgba(16, 24, 64, 0.2);
+  backdrop-filter: blur(8px);
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.title {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.2rem;
+  letter-spacing: 0.02em;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 0.8rem;
+}
+
+.message {
+  flex: 1 1 100%;
+  margin: 0;
+  text-align: left;
+  font-size: 0.9rem;
+  color: rgba(27, 33, 53, 0.75);
+}
+
+#reset-btn {
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+  box-shadow: 0 15px 25px rgba(77, 116, 255, 0.35);
+}
+
+#reset-btn:hover,
+#reset-btn:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 30px rgba(77, 116, 255, 0.4);
+  outline: none;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(var(--board-size, 10), 1fr);
+  gap: 0.4rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 16px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(6px);
+}
+
+.tile {
+  position: relative;
+  width: 100%;
+  padding-top: 100%;
+  border: 1px solid var(--tile-border);
+  border-radius: 10px;
+  background: var(--tile-bg);
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1d2b4f;
+  cursor: pointer;
+  transition: transform 80ms ease, background 150ms ease;
+}
+
+.tile:focus-visible {
+  outline: 3px solid rgba(77, 116, 255, 0.5);
+}
+
+.tile.revealed {
+  background: var(--tile-revealed);
+  cursor: default;
+  border-color: rgba(77, 116, 255, 0.2);
+}
+
+.tile.revealed.mine {
+  background: #ff4d61;
+  color: white;
+  font-weight: 700;
+}
+
+.tile.flagged::after {
+  content: "🚩";
+  position: absolute;
+  font-size: 1.4rem;
+}
+
+.tile.revealed.flagged::after {
+  content: "";
+}
+
+.tile span {
+  position: absolute;
+}
+
+.hint {
+  text-align: center;
+  color: rgba(27, 33, 53, 0.75);
+  font-size: 0.9rem;
+}
+
+.hint p {
+  margin: 0;
+}
+
+@media (max-width: 520px) {
+  .board {
+    gap: 0.3rem;
+    padding: 0.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a lightweight static Minesweeper-inspired web app under web/minesweeper
- implement interactive gameplay with mine placement, flagging, and win/loss states
- style the board with responsive, glassmorphism-inspired visuals and accessibility hints

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_69088d64db10832e9129a12473622ca3